### PR TITLE
Added the ability to display a brief help on all features of the add-on

### DIFF
--- a/addon/globalPlugins/developerToolkit/__init__.py
+++ b/addon/globalPlugins/developerToolkit/__init__.py
@@ -415,14 +415,12 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	@script(description=u"Brief help on available features")
 	def script_help(self, gesture):
 		messages = []
-		for attr in dir(self):
-			if attr.lower().startswith("script_"):
+		attrs = [attr for attr in dir(self) if attr.lower().startswith("script_")]
+		for gest,func in self.__developerToolkitGestures.items():
+			for attr in attrs:
 				message = getattr(self, attr).__doc__
-				attr = attr.replace('script_', '')
-				for gest,func in self.__developerToolkitGestures.items():
-					if attr==func:
-						message = f"{gest.replace('kb:', '')} - {message}"
-				messages.append(message)
+				if attr.replace('script_', '')==func:
+					messages.append(f"{gest.replace('kb:', '')} - {message}")
 		ui.browseableMessage('\n'.join(messages), self.script_help.__doc__, False)
 
 	__developerToolkitGestures = {
@@ -452,6 +450,5 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		"kb:shift+s": "SpeakStates",
 		"kb:t": "SpeakObjectTopPosition",
 		"kb:v": "SpeakVersion",
-		"kb:w": "SpeakObjectWidth",
 		"kb:`": "help",
 	}

--- a/addon/globalPlugins/developerToolkit/__init__.py
+++ b/addon/globalPlugins/developerToolkit/__init__.py
@@ -412,6 +412,19 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		elif getLastScriptRepeatCount() >= 1:
 			shared.copyToClipboard(message)
 
+	@script(description=u"Brief help on available features")
+	def script_help(self, gesture):
+		messages = []
+		for attr in dir(self):
+			if attr.lower().startswith("script_"):
+				message = getattr(self, attr).__doc__
+				attr = attr.replace('script_', '')
+				for gest,func in self.__developerToolkitGestures.items():
+					if attr==func:
+						message = f"{gest.replace('kb:', '')} - {message}"
+				messages.append(message)
+		ui.browseableMessage('\n'.join(messages), self.script_help.__doc__, False)
+
 	__developerToolkitGestures = {
 		"kb:alt+windows+k": "ToggleFeatures",
 		"kb:leftArrow": "MoveToPreviousSibling",
@@ -440,4 +453,5 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		"kb:t": "SpeakObjectTopPosition",
 		"kb:v": "SpeakVersion",
 		"kb:w": "SpeakObjectWidth",
+		"kb:`": "help",
 	}


### PR DESCRIPTION
Due to the large number of functions of the add-on, it would be convenient to have a list of them and shortcuts attached to them.
Now when the add-on mode is enabled, you can call up a dialog box with a list of all available functions by pressing the <`>.
I often use this feature, I hope it will also be useful for other users.
Good luck!
